### PR TITLE
updating Makefile to include sync-time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help: ## Display this help.
 LOCAL_PYSQUARED ?= ""
 
 .PHONY: download-libraries
-download-libraries: .venv ## Download the required libraries
+download-libraries: uv .venv ## Download the required libraries
 	@echo "Downloading libraries..."
 	@$(UV) pip install --requirement lib/requirements.txt --target lib --no-deps --upgrade --quiet; \
 
@@ -33,6 +33,10 @@ download-libraries: .venv ## Download the required libraries
 pre-commit-install: uv
 	@echo "Installing pre-commit hooks..."
 	@$(UVX) pre-commit install > /dev/null
+
+.PHONY: sync-time
+sync-time: uv ## Syncs th time from your computer to the PROVES Kit board
+	$(UVX) --from git+https://github.com/proveskit/sync-time@1.0.0 sync-time
 
 .PHONY: fmt
 fmt: pre-commit-install ## Lint and format files


### PR DESCRIPTION
## Summary
As sync-time functionality now lives in https://github.com/proveskit/sync-time, it will be installed through the use of uv

## How was this tested
- [ ] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)

You will see that the default time on the board is January 1, 2000, but running make sync-time updates the time on the board and the correct time is updated

<img width="853" alt="Screenshot 2025-03-28 at 5 36 23 PM" src="https://github.com/user-attachments/assets/5ad605b9-051e-4353-a0b6-dbc198a34779" />
<img width="1001" alt="Screenshot 2025-03-28 at 5 37 37 PM" src="https://github.com/user-attachments/assets/1be02561-ac7e-49fa-bcbf-72457f68d334" />
<img width="973" alt="Screenshot 2025-03-28 at 5 37 19 PM" src="https://github.com/user-attachments/assets/8bb9b3f0-2fa9-41a2-b7de-73470d2d2c46" />