### PR TITLE
removing extra argument (version) and flipping the logger and config arguments in Satellite object construction in the REPL

### DIFF
--- a/repl.py
+++ b/repl.py
@@ -5,7 +5,6 @@ from lib.pysquared.config.config import Config
 from lib.pysquared.logger import Logger
 from lib.pysquared.nvm.counter import Counter
 from lib.pysquared.satellite import Satellite
-from version import __version__
 
 logger: Logger = Logger(
     error_counter=Counter(index=register.ERRORCNT, datastore=microcontroller.nvm),
@@ -13,4 +12,4 @@ logger: Logger = Logger(
 )
 config: Config = Config("config.json")
 logger.info("Initializing a cubesat object as `c` in the REPL...")
-c: Satellite = Satellite(config, logger, __version__)
+c: Satellite = Satellite(logger, config)


### PR DESCRIPTION
## Summary
As the new satellite constructor only takes in config and logger parameters, this was causing an error in the REPL.
I also realized that the logger and config arguments were flipped, so I fixed that

## How was this tested
- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
